### PR TITLE
Handle null pointer exception crash

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
+++ b/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
@@ -116,7 +116,7 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
 
     //GUARD : make sure we have a job
     final ExportJob job = consumeJob();
-    if (exportJob == null) return false;
+    if (job == null) return false;
 
 
     // -- past this point we are consuming the result

--- a/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
+++ b/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
@@ -127,6 +127,7 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
     }
 
     // Unhandled case
+    result.error("Unknown result", null, null);
     return false;
   }
 

--- a/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
+++ b/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
@@ -108,6 +108,8 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
   public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
 
     if (BuildConfig.DEBUG) {
+      Log.d("ExportPlugin", "onActivityResult: requestCode = " + requestCode);
+      Log.d("ExportPlugin", "onActivityResult: resultCode = " + resultCode);
       Log.d("ExportPlugin", "onActivityResult: intent = " + intent);
     }
 
@@ -116,8 +118,8 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
 
     //GUARD : make sure we have a job
     final ExportJob job = consumeJob();
+    if (BuildConfig.DEBUG) Log.d("ExportPlugin", "onActivityResult: exportJob = " + job);
     if (job == null) return false;
-
 
     // -- past this point we are consuming the result
 
@@ -127,7 +129,6 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
     try {
 
       if (resultCode == RESULT_CANCELED) {
-        // If we get a cancelled result, we should reset the result and path
         result.error("cancelled", "User cancelled the export", null);
       }
 

--- a/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
+++ b/android/src/main/java/com/SplashPad/export_plugin/ExportPlugin.java
@@ -146,7 +146,7 @@ public class ExportPlugin implements FlutterPlugin, MethodCallHandler, ActivityR
         result.error("unknown_result_code", "Unknown result code returned by OS: " + resultCode, null);
       }
     } catch (final Throwable e) {
-      result.error("Failed to save file", e.getMessage(), e);
+      result.error("save_failed", e.getMessage(), e);
     }
 
     return true;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,17 +25,16 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.SplashPad.export_plugin_example"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 23
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -43,8 +42,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/lib/export_plugin.dart
+++ b/lib/export_plugin.dart
@@ -34,29 +34,6 @@ class ExportPlugin {
     return _channel.invokeMethod('export', params);
   }
 
-  static Future<void> openFile(
-      String uri, {
-        String subject,
-        Rect sharePositionOrigin,
-      }) {
-    assert(uri != null);
-    assert(uri.isNotEmpty);
-
-    final Map<String, dynamic> params = <String, dynamic>{
-      'uri': uri,
-      'subject': subject,
-    };
-
-    if (sharePositionOrigin != null) {
-      params['originX'] = sharePositionOrigin.left;
-      params['originY'] = sharePositionOrigin.top;
-      params['originWidth'] = sharePositionOrigin.width;
-      params['originHeight'] = sharePositionOrigin.height;
-    }
-
-    return _channel.invokeMethod<void>('open', params);
-  }
-
   static String _mimeTypeForFile(File file) {
     assert(file != null);
     final String path = file.path;


### PR DESCRIPTION
Looking at the crash report, it seems the plugin is trying to fire off a result.error back through the Method Channel but it is unable to do so because the result property has been nulled.

I am unable to re-create the crash the users are getting.

Based on an **assumption** that onActivityResult is returning a CANCEL and an OK result,
I have added safety checks to ensure that onActivityResult only returns either the CANCEL or the OK, but not both

This PR contains :
- Change logic to avoid unexpected multiple onactivityresult calls
- Remove unused methods

[Issue Ticket](https://www.notion.so/popgun/Export-share-crash-issue-d9b78653cbbd497a86972a75af67d44c)

[Firebase Crash Report](https://console.firebase.google.com/u/0/project/splashpad/crashlytics/app/android:ai.popgun.splashpad/issues/e23e67a3c9defb8037277544b39720d9?time=last-seven-days&sessionId=5E61B5D4031000010417229F7B3DC0EC_DNE_0_v2)
